### PR TITLE
Prepare for possible etoc internal renamings

### DIFF
--- a/source/latex/yathesis/yathesis.dtx
+++ b/source/latex/yathesis/yathesis.dtx
@@ -1220,7 +1220,7 @@ This work consists of the file  yathesis.dtx
       \def\YAD@localtocsdepth{#1}%
     }%
     \ifboolexpr{%
-      test {\@ifundefined {Etoc@\YAD@localtocsdepth @@}}
+      test {\etocunknownlevelTF {\YAD@localtocsdepth}}
       or %
       test {\ifstrequal{#1}{part}}
       or %
@@ -1562,6 +1562,7 @@ This work consists of the file  yathesis.dtx
 % Pour pouvoir afficher un sommaire c-à-d une table des matières réduite
 %    \begin{macrocode}
 \RequirePackage{etoc}[2016/09/29]%
+\providecommand*\etocunknownlevelTF[1]{\@ifundefined{Etoc@#1@@}}%
 %    \end{macrocode}
 % La commande suivante est une solution de contournement fournie par le paquet
 % etoc afin de résoudre le problème
@@ -3595,7 +3596,7 @@ This work consists of the file  yathesis.dtx
           }%
           \newcommand\tableofcontents@YAD@with@argument[1][]{%
             \yadsetup{#1}%
-            \@ifundefined {Etoc@\cmdKV@YAD@depth @@}
+            \etocunknownlevelTF {\cmdKV@YAD@depth}
             {%
               \YAD@ClassWarningNoLine{%
                 La valeur (`\cmdKV@YAD@depth') passée à la clé `depth'\MessageBreak%
@@ -5735,13 +5736,13 @@ This work consists of the file  yathesis.dtx
   {%
     \bgroup
     \YAD@localstyle%
-    \@ifundefined {Etoc@\YAD@localtocsdepth @@}
+    \etocunknownlevelTF {\YAD@localtocsdepth}
     {%
     }{%
       \etocsetnexttocdepth{\YAD@localtocsdepth}%
     }
     \YAD@computelocalnumwidths\relax%
-    \@ifundefined {Etoc@\YAD@localtocsdepth @@}
+    \etocunknownlevelTF {\YAD@localtocsdepth}
     {%
     }{%
       \etocsetnexttocdepth{\YAD@localtocsdepth}%

--- a/source/latex/yathesis/yathesis.dtx
+++ b/source/latex/yathesis/yathesis.dtx
@@ -1220,7 +1220,7 @@ This work consists of the file  yathesis.dtx
       \def\YAD@localtocsdepth{#1}%
     }%
     \ifboolexpr{%
-      test {\etocunknownlevelTF {\YAD@localtocsdepth}}
+      test {\etocifunknownlevelTF {\YAD@localtocsdepth}}
       or %
       test {\ifstrequal{#1}{part}}
       or %
@@ -1562,7 +1562,7 @@ This work consists of the file  yathesis.dtx
 % Pour pouvoir afficher un sommaire c-à-d une table des matières réduite
 %    \begin{macrocode}
 \RequirePackage{etoc}[2016/09/29]%
-\providecommand*\etocunknownlevelTF[1]{\@ifundefined{Etoc@#1@@}}%
+\providecommand*\etocifunknownlevelTF[1]{\@ifundefined{Etoc@#1@@}}%
 %    \end{macrocode}
 % La commande suivante est une solution de contournement fournie par le paquet
 % etoc afin de résoudre le problème
@@ -3596,7 +3596,7 @@ This work consists of the file  yathesis.dtx
           }%
           \newcommand\tableofcontents@YAD@with@argument[1][]{%
             \yadsetup{#1}%
-            \etocunknownlevelTF {\cmdKV@YAD@depth}
+            \etocifunknownlevelTF {\cmdKV@YAD@depth}
             {%
               \YAD@ClassWarningNoLine{%
                 La valeur (`\cmdKV@YAD@depth') passée à la clé `depth'\MessageBreak%
@@ -5736,13 +5736,13 @@ This work consists of the file  yathesis.dtx
   {%
     \bgroup
     \YAD@localstyle%
-    \etocunknownlevelTF {\YAD@localtocsdepth}
+    \etocifunknownlevelTF {\YAD@localtocsdepth}
     {%
     }{%
       \etocsetnexttocdepth{\YAD@localtocsdepth}%
     }
     \YAD@computelocalnumwidths\relax%
-    \etocunknownlevelTF {\YAD@localtocsdepth}
+    \etocifunknownlevelTF {\YAD@localtocsdepth}
     {%
     }{%
       \etocsetnexttocdepth{\YAD@localtocsdepth}%


### PR DESCRIPTION
Bonjour Denis, j'ai écrit un beau message de commit en anglais et tout, donc je ne traduis pas.

The macro `\etocunknownlevelTF` will be provided in future releases of [etoc](https://ctan.org/pkg/etoc), to check if the argument is known to etoc as a genuine sectioning level.  This commit provides the command, so that if etoc changes its internal naming in a future release, its version of `\etocunknownlevelTF` will be the one used.  The current one works will all etoc releases at least up to 1.1c.

(c'est-à-dire la version de ce commit marche avec tous les etoc au moins jusqu'à 1.1c, et probablement un peu au-delà, car je vais attendre que yathesis.cls soit protégé par le `\providecommand` -- peut-être pour TL2023? les changements éventuels de etoc en interne peuvent attendre après sans problème)