### PR TITLE
fix: ✏️ typos dans le disclaimer

### DIFF
--- a/source/latex/yathesis/olirwin
+++ b/source/latex/yathesis/olirwin
@@ -6294,10 +6294,12 @@ This work consists of the file  yathesis.dtx
     leurs auteurs.%
   }{%
     The \printinstitute{}
-    %
-    \ifundef{\printcoinstitute}{}{and the \printcoinstitute{}}
-    %
-    neither endorse nor censure authors' opinions expressed in the theses:
+    \ifundef{\printcoinstitute}{%
+      neither endorses nor censures
+    }{%
+      and the \printcoinstitute{} neither endorse nor censure
+    }%
+    the authors' opinions expressed in the thesis:
     these opinions must be considered to be those of their authors.%
   }%
 }%


### PR DESCRIPTION
Bonjour bonjour,

En compilant un manuscrit, je me suis rendu compte d'une légère typo dans le `disclaimer` sur la traduction en anglais. 
C'est corrigé :)

Bon courage et merci encore pour yathesis :smile: 